### PR TITLE
Fixes license for setuptools  > v56.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='pyrle',
       author="Endre Bakken Stovner",
       author_email="endrebak85@gmail.com",
       url="https://github.com/endrebak/pyrle",
-      license=["MIT"],
+      license="MIT",
       classifiers=[
           "Programming Language :: Python :: 3",
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
I got the following error when trying to install with setuptools==57.0.0

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-obm7mx6j/setup.py", line 29, in <module>
        setup(name='pyrle',
      File "/home/mathieu/miniconda3/envs/MC2021-04-22/lib/python3.9/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/home/mathieu/miniconda3/envs/MC2021-04-22/lib/python3.9/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/home/mathieu/miniconda3/envs/MC2021-04-22/lib/python3.9/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/home/mathieu/.local/share/virtualenvs/pps-xKT5X8cF/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 292, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/home/mathieu/.local/share/virtualenvs/pps-xKT5X8cF/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 635, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/home/mathieu/miniconda3/envs/MC2021-04-22/lib/python3.9/distutils/dist.py", line 1117, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/home/mathieu/.local/share/virtualenvs/pps-xKT5X8cF/lib/python3.9/site-packages/setuptools/dist.py", line 185, in write_pkg_file
        license = rfc822_escape(self.get_license())
      File "/home/mathieu/miniconda3/envs/MC2021-04-22/lib/python3.9/distutils/util.py", line 476, in rfc822_escape
        lines = header.split('\n')
    AttributeError: 'list' object has no attribute 'split'

It was  fine with  setuptools==52.0.0.

I think the change occur in setuptool 56.1.0 : https://github.com/pypa/setuptools/commit/c36033859ec2f7d9034a93c363ffc858ffbae172#diff-b64ef3dbcb447d2cfc0a81bcba734f9f7d58440adcc078fb23a31949b7c723d4

There is a new line checking the license and the license=["MIT"] is now invalid.