### PR TITLE
- Fix `AttributeError: module 'pyranges' has no attribute 'from_dfs'`…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+# 0.0.38 (08.04.2024) (@Isy89)
+- Fix `AttributeError: module 'pyranges' has no attribute 'from_dfs'` causing to_ranges function to return a pandas 
+  Dataframe instead of PyRanges object (#9)
+  
 # 0.0.37 (18.05.23)
 - remove option to return 32-bit PyRanges
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyrle"
-version = "0.0.39"
+version = "0.0.40"
 description = "Numeric run length encoding for Python."
 readme = "README.md"
 authors = [{ name = "Endre Bakken Stovner", email = "endbak@pm.me" }]


### PR DESCRIPTION
… causing to_ranges function to return a pandas Dataframe instead of PyRanges object (#9)

- Logging exception in case the to_ranges function fails at creating the pr.PyRanges object
- adding Exception (PEP 8: E722)